### PR TITLE
feat(audio-data): implement service, controller, and unit tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,25 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.2</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <version>3.4.1</version>
+        <relativePath/>
     </parent>
     <groupId>com.soundowner</groupId>
     <artifactId>soundspace</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>soundspace</name>
-    <description>Demo project for Spring Boot</description>
+    <description>SoundSpace - Reactive Music BFF</description>
+
     <properties>
         <java.version>17</java.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-web</artifactId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <dependency>
@@ -27,6 +35,18 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>4.12.0</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -34,8 +54,15 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                        </exclude>
+                    </excludes>
+                </configuration>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/src/main/java/com/soundowner/config/QobuzProperties.java
+++ b/src/main/java/com/soundowner/config/QobuzProperties.java
@@ -1,0 +1,16 @@
+package com.soundowner.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "qobuz")
+@Data
+public class QobuzProperties {
+    private String appId;
+    private String appSecret;
+    private String qobuzBaseUrl;
+    private String userAuthToken;
+    private String userAlternativeAuthToken;
+}

--- a/src/main/java/com/soundowner/config/WebClientConfig.java
+++ b/src/main/java/com/soundowner/config/WebClientConfig.java
@@ -1,0 +1,16 @@
+package com.soundowner.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient(QobuzProperties qobuzProperties) {
+        return WebClient.builder()
+                .baseUrl(qobuzProperties.getQobuzBaseUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/soundowner/controller/QobuzController.java
+++ b/src/main/java/com/soundowner/controller/QobuzController.java
@@ -1,0 +1,26 @@
+package com.soundowner.controller;
+
+import com.soundowner.service.QobuzApiService;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/data/audio")
+public class QobuzController {
+
+    private final QobuzApiService qobuzApiService;
+
+    public QobuzController(QobuzApiService qobuzApiService) {
+        this.qobuzApiService = qobuzApiService;
+    }
+
+    @GetMapping("/search")
+    public Mono<String> search(@RequestParam String query, @RequestParam(required = false) String type) {
+        return qobuzApiService.search(query, type);
+    }
+
+    @GetMapping("/artists/{artistId}")
+    public Mono<String> getArtistWithAlbums(@PathVariable String artistId) {
+        return qobuzApiService.getArtistWithAlbums(artistId);
+    }
+}

--- a/src/main/java/com/soundowner/service/QobuzApiService.java
+++ b/src/main/java/com/soundowner/service/QobuzApiService.java
@@ -1,0 +1,157 @@
+package com.soundowner.service;
+
+import com.soundowner.config.QobuzProperties;
+import com.soundowner.util.HashUtils; // Импорт нового утилитного класса
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.Instant;
+
+@Service
+@Slf4j
+public class QobuzApiService {
+    private final QobuzProperties properties;
+    private final WebClient webClient;
+    @Setter
+    private volatile String validSearchToken;
+    @Setter
+    private volatile String validFileUrlToken;
+
+    /**
+     * Конструктор сервиса Qobuz API.
+     *
+     * @param properties  конфигурация поиска и API ключей
+     * @param webClient   настроенный экземпляр {@link WebClient} для запросов к Qobuz
+     */
+    public QobuzApiService(QobuzProperties properties, WebClient webClient) {
+        this.properties = properties;
+        this.webClient = webClient;
+        this.validSearchToken = properties.getUserAuthToken();
+        this.validFileUrlToken = properties.getUserAuthToken();
+    }
+
+    /**
+     * Переключает токен поиска между основным и дополнительным.
+     * Используется при ошибках или ограничениях на текущий токен.
+     */
+    public void replaceSearchToken(){
+        if(validSearchToken.equals(properties.getUserAuthToken())){
+            this.validSearchToken = properties.getUserAlternativeAuthToken();
+        }else {
+            this.validSearchToken = properties.getUserAuthToken();
+        }
+        log.info("search token replaced");
+    }
+
+    /**
+     * Переключает токен для получения файлов между основным и дополнительным.
+     * Используется при ошибках получения URL.
+     */
+    public void replaceFileUrlToken(){
+        if(validFileUrlToken.equals(properties.getUserAuthToken())){
+            this.validFileUrlToken = properties.getUserAlternativeAuthToken();
+        }else {
+            this.validFileUrlToken = properties.getUserAuthToken();
+        }
+        log.info("fileUrl token replaced");
+    }
+
+    /**
+     * Выполняет поиск по каталогу Qobuz.
+     *
+     * @param query поисковый запрос (например, имя исполнителя или название трека)
+     * @param type  тип поиска (tracks, albums, artists и пр.), если null или пусто — используется "tracks"
+     * @return      Mono с JSON-строкой ответа от API Qobuz
+     */
+    public Mono<String> search(String query, String type) {
+        String url = UriComponentsBuilder.fromUriString(properties.getQobuzBaseUrl() + "catalog/search")
+                .queryParam("app_id", properties.getAppId())
+                .queryParam("query", query)
+                .queryParam("type", type !=null && !type.isEmpty() ? type : "tracks")
+                .queryParam("user_auth_token", validSearchToken)
+                .toUriString();
+
+        log.info("Requesting URL: {}", url); // Логирование URL для отладки
+
+        return webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .doOnNext(res -> log.debug("Qobuz search success for query: {}", query))
+                .doOnError(e -> log.error("Qobuz search failed for query: {}. Error: {}", query, e.getMessage()))
+                .log()// Логирование всех событий Mono
+                .timeout(Duration.ofSeconds(5));
+    }
+
+    /**
+     * Получает URL для стриминга или загрузки файла трека.
+     *
+     * @param trackId  ID трека в каталоге Qobuz
+     * @param formatId ID формата файла (например, 6 для FLAC 16-bit)
+     * @return         Mono с JSON-строкой ответа от API Qobuz (ссылка и параметры файла)
+     */
+    public Mono<String> getFileUrl(int trackId, Integer formatId) {
+        long timestamp = Instant.now().getEpochSecond();
+        String signatureRaw = String.format("trackgetFileUrlformat_id%sintentstreamtrack_id%s%s%s",
+                formatId, trackId, timestamp, properties.getAppSecret());
+
+        String signature = HashUtils.calculateMD5(signatureRaw); // Использование утилитарного класса
+
+        String url = UriComponentsBuilder.fromUriString(properties.getQobuzBaseUrl() + "track/getFileUrl")
+                .queryParam("app_id", properties.getAppId())
+                .queryParam("track_id", trackId)
+                .queryParam("format_id", formatId != null ? formatId : 27)
+                .queryParam("intent", "stream")
+                .queryParam("request_ts", timestamp)
+                .queryParam("request_sig", signature)
+                .queryParam("user_auth_token", validFileUrlToken)
+                .toUriString();
+
+
+        return webClient.get()
+                .uri(url)
+                .header("X-User-Auth-Token", validFileUrlToken) // добавляем заголовок
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorResume(e -> Mono.error(new RuntimeException("Ошибка при вызове Qobuz getFileUrl", e)));
+    }
+
+
+    public Mono<String> getArtistWithAlbums(String artistId) {
+        String url = UriComponentsBuilder.fromUriString(properties.getQobuzBaseUrl() + "artist/get")
+                .queryParam("app_id", properties.getAppId())
+                .queryParam("artist_id", artistId)
+                .queryParam("type", "artists")
+                .queryParam("extra", "albums")
+                .queryParam("limit", 100)
+                .queryParam("user_auth_token", validSearchToken)
+                .toUriString();
+
+        return webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorResume(e -> Mono.error(new RuntimeException("Ошибка при вызове Qobuz artist/get", e)));
+    }
+
+    public Mono<String> getAlbumById(String albumId) {
+        String url = UriComponentsBuilder.fromUriString(properties.getQobuzBaseUrl() + "album/get")
+                .queryParam("app_id", properties.getAppId())
+                .queryParam("album_id", albumId)
+                .queryParam("type", "albums")
+                .queryParam("limit", 100)
+                .queryParam("user_auth_token", validSearchToken)
+                .toUriString();
+
+        return webClient.get()
+                .uri(url)
+                .retrieve()
+                .bodyToMono(String.class)
+                .onErrorResume(e -> Mono.error(new RuntimeException("Ошибка при вызове Qobuz album/get", e)));
+    }
+}

--- a/src/main/java/com/soundowner/util/HashUtils.java
+++ b/src/main/java/com/soundowner/util/HashUtils.java
@@ -1,0 +1,32 @@
+package com.soundowner.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+
+public class HashUtils {
+
+    private HashUtils() {
+        // Приватный конструктор, чтобы предотвратить создание экземпляров утилитного класса
+    }
+
+    /**
+     * Вычисляет MD5-хэш для заданной строки.
+     *
+     * @param input входная строка
+     * @return      строка хэша в шестнадцатеричном виде
+     * @throws RuntimeException если алгоритм MD5 недоступен в JVM
+     */
+    public static String calculateMD5(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+            byte[] hash = md.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e){
+            throw new RuntimeException("Error calculating MD5", e);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+    <logger name="org.springframework.web.server.adapter.HttpWebHandlerAdapter" level="TRACE" />
+</configuration>

--- a/src/test/java/com/soundowner/service/QobuzApiServiceTest.java
+++ b/src/test/java/com/soundowner/service/QobuzApiServiceTest.java
@@ -1,0 +1,116 @@
+package com.soundowner.service;
+
+import com.soundowner.config.QobuzProperties;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QobuzApiServiceTest {
+
+    private static MockWebServer mockWebServer;
+    private QobuzApiService qobuzApiService;
+    private QobuzProperties properties;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @BeforeEach
+    void initialize() {
+        String baseUrl = String.format("http://localhost:%s/", mockWebServer.getPort());
+
+        properties = new QobuzProperties();
+        properties.setQobuzBaseUrl(baseUrl);
+        properties.setAppId("test-app-id");
+        properties.setAppSecret("test-secret");
+        properties.setUserAuthToken("primary-token");
+        properties.setUserAlternativeAuthToken("backup-token");
+
+        WebClient webClient = WebClient.builder().baseUrl(baseUrl).build();
+        qobuzApiService = new QobuzApiService(properties, webClient);
+    }
+
+    @Test
+    void getFileUrl_ShouldIncludeSignatureAndCustomHeader() throws InterruptedException {
+        // Arrange
+        mockWebServer.enqueue(new MockResponse().setBody("{\"url\": \"http://stream.qobuz.com/123\"}"));
+
+        // Act
+        qobuzApiService.getFileUrl(555, 6).block();
+
+        // Assert
+        RecordedRequest request = mockWebServer.takeRequest();
+        assertNotNull(request);
+        String path = request.getPath();
+        assertNotNull(path);
+
+        // Проверяем наличие обязательных параметров для этого метода
+        assertTrue(path.contains("request_ts="), "Должен быть timestamp");
+        assertTrue(path.contains("request_sig="), "Должна быть MD5 подпись");
+        assertTrue(path.contains("format_id=6"));
+
+        // Проверяем кастомный заголовок
+        assertEquals("primary-token", request.getHeader("X-User-Auth-Token"));
+    }
+
+    @Test
+    void replaceSearchToken_ShouldEffectivelySwitchTokens() throws InterruptedException {
+        // 1. Делаем первый запрос
+        mockWebServer.enqueue(new MockResponse().setBody("{}"));
+        qobuzApiService.search("q", "tracks").block();
+
+        RecordedRequest request1 = mockWebServer.takeRequest();
+        assertNotNull(request1);
+        HttpUrl url1 = request1.getRequestUrl();
+        assertNotNull(url1, "URL should not be null");
+        assertEquals("primary-token", url1.queryParameter("user_auth_token"));
+
+        // 2. Переключаем токен (имитируем реакцию на ошибку)
+        qobuzApiService.replaceSearchToken();
+
+        // 3. Делаем второй запрос - токен должен измениться
+        mockWebServer.enqueue(new MockResponse().setBody("{}"));
+        qobuzApiService.search("q", "tracks").block();
+
+        RecordedRequest request2 = mockWebServer.takeRequest();
+        assertNotNull(request2);
+        HttpUrl url2 = request2.getRequestUrl();
+        assertNotNull(url2, "URL should not be null");
+        assertEquals("backup-token", url2.queryParameter("user_auth_token"));
+    }
+
+    @Test
+    void getAlbumById_ShouldHandleApiError() {
+        // Arrange: Эмулируем 500 ошибку от API Qobuz
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        // Act
+        Mono<String> result = qobuzApiService.getAlbumById("album-123");
+
+        // Assert: Проверяем, что сработал onErrorResume
+        StepVerifier.create(result)
+                .expectErrorMatches(throwable -> throwable instanceof RuntimeException
+                        && throwable.getMessage().contains("Ошибка при вызове Qobuz album/get"))
+                .verify();
+    }
+}


### PR DESCRIPTION
- Implement QobuzApiService with WebClient for Qobuz API interactions.

- Add QobuzController to expose /search and /artists/{artistId} endpoints.

- Refactor MD5 signature generation into a dedicated HashUtils utility class.

- Introduce a unit test for QobuzApiService using MockWebServer and StepVerifier.