### PR TITLE
feat(security): Parameterize authentication and proxy settings for cr…

### DIFF
--- a/auth-server/src/main/java/com/soundowner/auth/config/OAuth2SuccessHandler.java
+++ b/auth-server/src/main/java/com/soundowner/auth/config/OAuth2SuccessHandler.java
@@ -22,6 +22,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtService jwtService;
     private final UserRepository userRepository;
 
+    @org.springframework.beans.factory.annotation.Value("${app.frontend-url}")
+    private String frontendUrl;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
@@ -56,8 +59,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         sessionCookie.setMaxAge(0);
         response.addCookie(sessionCookie);
 
-        // Динамический редирект на основе заголовков прокси (Gateway)
-        String redirectUrl = getBaseUrl(request) + "/index.html";
+        // Динамический редирект на основе конфига
+        String redirectUrl = frontendUrl + "/index.html";
         
         getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }

--- a/auth-server/src/main/java/com/soundowner/auth/controller/AuthController.java
+++ b/auth-server/src/main/java/com/soundowner/auth/controller/AuthController.java
@@ -20,6 +20,9 @@ public class AuthController {
 
     private final AuthService authService;
 
+    @org.springframework.beans.factory.annotation.Value("${app.frontend-url}")
+    private String frontendUrl;
+
     // ... импорты
 
     // Добавляем новый метод для обновления токенов
@@ -31,12 +34,9 @@ public class AuthController {
             HttpServletRequest request
     ) throws IOException, java.io.IOException {
 
-        System.out.println("REFRESH_TOKEN RECEIVED: " + refreshToken);
-
         // 1. Если токена нет — отправляем логиниться
         if (refreshToken == null) {
-            String baseUrl =  getBaseUrl(request);
-            response.sendRedirect(baseUrl + "/login.html");
+            response.sendRedirect(frontendUrl + "/login.html");
             return;
         }
 
@@ -44,12 +44,15 @@ public class AuthController {
             // 2. Валидация и поход в БД (внутри сервиса)
             String[] newTokens = authService.refreshToken(refreshToken);
 
+            boolean isSecure = frontendUrl.startsWith("https");
+
             // 3. Установка новых кук
             // Access Token (перезаписываем)
             Cookie accessCookie = new Cookie("ACCESS_TOKEN", newTokens[0]);
             accessCookie.setHttpOnly(true);
             accessCookie.setPath("/");
             accessCookie.setMaxAge(900); // 15 мин
+            accessCookie.setSecure(isSecure);
             response.addCookie(accessCookie);
 
             // Refresh Token (продляем жизнь или меняем)
@@ -57,14 +60,14 @@ public class AuthController {
             refreshCookie.setHttpOnly(true);
             refreshCookie.setPath("/"); 
             refreshCookie.setMaxAge(604800); // 7 дней
+            refreshCookie.setSecure(isSecure);
             response.addCookie(refreshCookie);
 
-            // 4. Редирект домой (Dynamic)
-            response.sendRedirect(getBaseUrl(request) + "/");
+            // 4. Редирект домой (из конфига)
+            response.sendRedirect(frontendUrl + "/");
 
         } catch (Exception e) {
             System.err.println("Refresh failed: " + e.getMessage());
-            e.printStackTrace();
             
             Cookie deleteAccess = new Cookie("ACCESS_TOKEN", null);
             deleteAccess.setPath("/");
@@ -76,7 +79,7 @@ public class AuthController {
             deleteRefresh.setMaxAge(0);
             response.addCookie(deleteRefresh);
 
-            response.sendRedirect(getBaseUrl(request) + "/login.html");
+            response.sendRedirect(frontendUrl + "/login.html");
         }
     }
 

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 server:
   port: 8081
-  forward-headers-strategy: framework
+  forward-headers-strategy: ${FORWARD_HEADERS_STRATEGY:framework}
   servlet:
     session:
       cookie:
@@ -35,10 +35,13 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "${BASE_URL}/login/oauth2/code/{registrationId}"
             scope:
               - email
               - profile
+
+app:
+  frontend-url: ${FRONTEND_URL:http://localhost:8080}
 
 jwt:
   secret: ${JWT_SECRET:very-long-and-secure-secret-key-that-must-be-at-least-256-bits}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       - "8080:8080"
     environment:
       - JWT_SECRET=${JWT_SECRET}
+      - GATEWAY_X_FORWARDED_PROTO=${GATEWAY_X_FORWARDED_PROTO:-true}
+      - GATEWAY_X_FORWARDED_HOST=${GATEWAY_X_FORWARDED_HOST:-true}
+      - GATEWAY_X_FORWARDED_PORT=${GATEWAY_X_FORWARDED_PORT:-true}
+      - GATEWAY_X_FORWARDED_FOR=${GATEWAY_X_FORWARDED_FOR:-true}
     depends_on:
       - auth-server
       - qobuz-api-gateway
@@ -41,6 +45,9 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/soundspace_db
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - BASE_URL=${BASE_URL}
+      - FRONTEND_URL=${FRONTEND_URL}
+      - FORWARD_HEADERS_STRATEGY=${FORWARD_HEADERS_STRATEGY:-framework}
       - JWT_SECRET=${JWT_SECRET}
     depends_on:
       postgres:

--- a/soundspace-gateway/src/main/resources/application.yml
+++ b/soundspace-gateway/src/main/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   cloud:
     gateway:
+      x-forwarded:
+        proto-enabled: ${GATEWAY_X_FORWARDED_PROTO:true}
+        host-enabled: ${GATEWAY_X_FORWARDED_HOST:true}
+        port-enabled: ${GATEWAY_X_FORWARDED_PORT:true}
+        for-enabled: ${GATEWAY_X_FORWARDED_FOR:true}
       routes:
         - id: auth-server
           uri: http://auth-server:8081


### PR DESCRIPTION
### Основные изменения:
   - **Параметризация окружения:** Внедрены переменные `FRONTEND_URL` и `BASE_URL`, заменяющие захардкоженные домены и динамическое вычисление адресов, которое ломалось за прокси.
   - **Гибкая настройка OAuth2:** Параметризованы `redirect-uri` и `forward-headers-strategy` в `auth-server`. Теперь переключение между локальным запуском и Nginx на VPS происходит через `.env`.
   - **Умная безопасность кук:** Флаг `Secure` для токенов теперь устанавливается автоматически, если `FRONTEND_URL` использует HTTPS.
   - **Конфигурация Gateway:** В `soundspace-gateway` добавлены настройки `x-forwarded` заголовков, которые можно отключать через переменные окружения для предотвращения конфликтов с внешними
   прокси-серверами.
   - **Docker Compose:** Все новые параметры проброшены в контейнеры с дефолтными значениями, обеспечивающими работу "из коробки" при локальном запуске.

   Это позволяет использовать один и тот же Docker-образ и код в разных средах, управляя поведением только через файл переменных окружения.